### PR TITLE
Support requests >= 1.0.

### DIFF
--- a/pyoauth2/client.py
+++ b/pyoauth2/client.py
@@ -73,4 +73,4 @@ class Client:
         params.update({'client_id': self.client_id,
                        'client_secret': self.client_secret,
                        'redirect_uri': self.redirect_uri})
-        return self.http_post(self.token_uri, params).json
+        return self.http_post(self.token_uri, params).json()

--- a/pyoauth2/tests/test_provider.py
+++ b/pyoauth2/tests/test_provider.py
@@ -10,7 +10,6 @@ class MockAuthorizationProvider(AuthorizationProvider):
 class AuthorizationProviderTest(unittest.TestCase):
 
     def setUp(self):
-
         self.provider = MockAuthorizationProvider()
 
     def test_make_redirect_error_response(self):
@@ -27,7 +26,7 @@ class AuthorizationProviderTest(unittest.TestCase):
 
         response = self.provider._make_json_error_response('some_error')
         self.assertEquals(400, response.status_code)
-        self.assertEquals({'error': 'some_error'}, response.json)
+        self.assertEquals({'error': 'some_error'}, response.json())
 
     def test_get_authorization_code_invalid_response_type(self):
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='OAuth 2.0 compliant client and server library.',
     long_description=open('README.txt').read(),
     install_requires=[
-        "requests >= 0.14",
+        "requests >= 1.1.0",
         "PyCrypto >= 2.6"
     ]
 )


### PR DESCRIPTION
This is a annoying, but anyone who pip installs requests (currently at 1.1.0) to satisfy your requests >= 0.14 dependency is in for a world of pain.  Might as well just force people to use the new version.

This very issue is discussed by @dcramer here: http://justcramer.com/2013/01/29/dependency-graphs-and-package-versioning/
