### PR TITLE
Use new-style classes

### DIFF
--- a/pyoauth2/client.py
+++ b/pyoauth2/client.py
@@ -2,7 +2,7 @@ import requests
 from . import utils
 
 
-class Client:
+class Client(object):
 
     def __init__(self, client_id, client_secret, redirect_uri, \
                  authorization_uri, token_uri):

--- a/pyoauth2/provider.py
+++ b/pyoauth2/provider.py
@@ -6,7 +6,7 @@ import werkzeug.exceptions
 from . import utils
 
 
-class Provider:
+class Provider(object):
     """Base provider class for different types of OAuth 2.0 providers."""
 
     def _handle_exception(self, exc):


### PR DESCRIPTION
Use python's new-style classes (inherit explicitly from 'object').  When I inherit from AuthorizationProvider, I'd expect to use the new super() syntax, super(MyAuthorizationProvider, self).**init**(), rather than the old-style AuthorizationProvider.**init**().  I know that AuthorizationProvider doesn't currently have an **init**() method, but if it adds one someday, I'll want to be sure that my subclass called it.

The difference between old- and new- style classes is described here: http://docs.python.org/2/reference/datamodel.html#new-style-and-classic-classes

Old-style classes are going away in python 3, so we might as well hop on board.
