### PR TITLE
Backwards-compatibility for requests and optional dependency on werkzeug

### DIFF
--- a/pyoauth2/client.py
+++ b/pyoauth2/client.py
@@ -73,4 +73,8 @@ class Client(object):
         params.update({'client_id': self.client_id,
                        'client_secret': self.client_secret,
                        'redirect_uri': self.redirect_uri})
-        return self.http_post(self.token_uri, params).json()
+        response = self.http_post(self.token_uri, params)
+        try:
+            return response.json()
+        except TypeError:
+            return response.json

--- a/pyoauth2/provider.py
+++ b/pyoauth2/provider.py
@@ -5,7 +5,7 @@ from cStringIO import StringIO
 try:
     from werkzeug.exceptions import Unauthorized
 except ImportError:
-    Unauthrorized = Exception
+    Unauthorized = Exception
 from . import utils
 
 

--- a/pyoauth2/provider.py
+++ b/pyoauth2/provider.py
@@ -2,7 +2,10 @@ import json
 import logging
 from requests import Response
 from cStringIO import StringIO
-import werkzeug.exceptions
+try:
+    from werkzeug.exceptions import Unauthorized
+except ImportError:
+    Unauthrorized = Exception
 from . import utils
 
 
@@ -525,7 +528,7 @@ class AuthorizationProvider(Provider):
                                   'discard_refresh_token.')
 
 
-class OAuthError(werkzeug.exceptions.Unauthorized):
+class OAuthError(Unauthorized):
     """OAuth error, including the OAuth error reason."""
     def __init__(self, reason, *args, **kwargs):
         self.reason = reason

--- a/pyoauth2/tests/test_provider.py
+++ b/pyoauth2/tests/test_provider.py
@@ -26,7 +26,11 @@ class AuthorizationProviderTest(unittest.TestCase):
 
         response = self.provider._make_json_error_response('some_error')
         self.assertEquals(400, response.status_code)
-        self.assertEquals({'error': 'some_error'}, response.json())
+        try:
+            response_json = response.json()
+        except TypeError:
+            response_json = response.json
+        self.assertEquals({'error': 'some_error'}, response_json)
 
     def test_get_authorization_code_invalid_response_type(self):
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='OAuth 2.0 compliant client and server library.',
     long_description=open('README.txt').read(),
     install_requires=[
-        "requests >= 1.1.0",
+        "requests >= 0.14",
         "PyCrypto >= 2.6"
     ]
 )


### PR DESCRIPTION
Hey there!

I've made a fairly minor adjustment to allow support for both requests 0.14.\* and 1.*, and also made the dependency on werkzeug optional. Figured it might make others' lives easier as well :)

Cheers!
