### PR TITLE
Ensure the oauth is an object not a class..

### DIFF
--- a/pyoauth2/provider.py
+++ b/pyoauth2/provider.py
@@ -572,7 +572,8 @@ class ResourceProvider(Provider):
 
     def get_authorization(self):
         """Get authorization object representing status of authentication."""
-        auth = self.authorization_class()
+        auth_class = self.authorization_class()
+        auth = auth_class()
         header = self.get_authorization_header()
         if not header or not header.split:
             return auth


### PR DESCRIPTION
Using a class like it was, would make it vulnerable to leaking the authorization the to other handlers in a multithreaded environment. Since classes are static.
