### PR TITLE
docs: fix simple typo, acheive -> achieve

### DIFF
--- a/pyoauth2/provider.py
+++ b/pyoauth2/provider.py
@@ -138,7 +138,7 @@ class AuthorizationProvider(Provider):
         discard_refresh_token(self, client_id, refresh_token)
             # Return value ignored
 
-    Optionally, the following may be overridden to acheive desired behavior:
+    Optionally, the following may be overridden to achieve desired behavior:
 
         @property
         token_length(self)


### PR DESCRIPTION
There is a small typo in pyoauth2/provider.py.

Should read `achieve` rather than `acheive`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md